### PR TITLE
Fix dependencies and add gitignore for IntelliJ

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ bin/
 *.bak
 *.swp
 *~
+
+# IntelliJ files
+.idea

--- a/build.xml
+++ b/build.xml
@@ -80,15 +80,6 @@
       </filterchain>
     </loadfile>
 
-    <!-- Manually update ivy.xml, setting the battlecode versions to ${bc.version}. 
-         Yes, it's horrible.
-         This is necessary because of limitations in the battlecode package repository;
-         it will be cleaner next year. -->
-    <replaceregexp file="ivy.xml" flags="g">
-      <regexp pattern="name=&quot;battlecode(-javadoc|-mapeditor)?&quot;(\s+)rev=&quot;[^&quot;]+&quot;"/>
-      <substitution expression="name=&quot;battlecode\1&quot;\2rev=&quot;${bc.version}&quot;"/>
-    </replaceregexp>
-
     <!-- Re-download all of our dependencies. -->
     <delete dir="${path.lib}"/>
     <mkdir dir="${path.lib}"/>

--- a/ivy.xml
+++ b/ivy.xml
@@ -16,14 +16,14 @@
   <dependencies>
     <!-- The main dependency we care about: battlecode, to be downloaded from
          battlecode.org. -->
-    <dependency org="battlecode" name="battlecode" rev="2016.0.1.0"
+    <dependency org="battlecode" name="battlecode" rev="2016.0.2.2"
       conf="default"/>
     <!-- And the battlecode javadoc, which we treat as a separate dependency
          to work around limitations in our package repository. -->
-    <dependency org="battlecode" name="battlecode-javadoc" rev="2016.0.1.0"
+    <dependency org="battlecode" name="battlecode-javadoc" rev="2016.0.2.2"
       conf="default"/>
     <!-- And the mapeditor! -->
-    <dependency org="battlecode" name="battlecode-mapeditor" rev="2016.0.1.0"
+    <dependency org="battlecode" name="battlecode-mapeditor" rev="2016.0.2.2"
       conf="default"/>
 
     <!-- Other dependencies, downloaded from the Maven Central Repository:


### PR DESCRIPTION
https://www.battlecode.org/contestants/latest/ currently points to the 2017 version of BattleCode. We want students to pull down the latest 2016 version. This removes the regex to update to the 2017 version and points the ivy.xml to the latest 2016.

Also add some IntelliJ specific gitignores under the IntelliJ folder.